### PR TITLE
issue 8:  reduce memory footprint of fnv hash func

### DIFF
--- a/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/HashFunctions.scala
+++ b/network/src/main/scala/com/linkedin/norbert/network/partitioned/loadbalancer/HashFunctions.scala
@@ -13,7 +13,10 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.linkedin.norbert.network.partitioned.loadbalancer
+package com.linkedin.norbert
+package network
+package partitioned
+package loadbalancer
 
 /**
  * Object which provides hash function implementations.
@@ -32,11 +35,14 @@ object HashFunctions {
     val FNV_BASIS = 0x811c9dc5
     val FNV_PRIME = (1 << 24) + 0x193
 
-    def fnv(key: Array[Byte], hash: Long): Int = {
-      if (key.length == 0) hash.toInt
-      else fnv(key.drop(1), (hash ^ (0xFF & key.first)) * FNV_PRIME)
-    }
+    var hash: Long = FNV_BASIS
+    var i: Int = 0
+    var maxIdx: Int = bytes.length
 
-    fnv(bytes, FNV_BASIS)
+    while (i < maxIdx) {
+      hash = (hash ^ (0xFF & bytes(i))) * FNV_PRIME
+      i += 1
+    }
+    hash.toInt
   }
 }


### PR DESCRIPTION
Although creating immutable objects is frequently better than creating mutable ones, creating immutable objects frequently is not as virtuous.
